### PR TITLE
Explicitly include the utility header on search result pages

### DIFF
--- a/header.php
+++ b/header.php
@@ -40,11 +40,14 @@
             if (is_archive()) {
                 get_header('archive');
             }
-            else if ('post' === get_post_type()) {
-                get_header('blog');
+            else if (is_search()) {
+                get_header('utility');
             }
             else if (in_array(get_post_type(), array('studentopportunities', 'student-support', 'institutes-centers', 'labs', 'support-science'))) {
                 get_header('utility');
+            }
+            else if ('post' === get_post_type()) {
+                get_header('blog');
             }
             else if (is_front_page()) {
                 get_header('home');


### PR DESCRIPTION
This PR addresses #113 

The search results page was showing the header for the first item in the result set. This change makes the search result page always use the "utility" header.